### PR TITLE
Run on Ubuntu 16.04.03

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 default:
-	gcc -O3 -o echo_server -s -Isrc src/*.c src/eventing/*.c examples/echo_server.c -lssl -lcrypto
+	gcc -O3 -DLIBUS_NO_SSL -o echo_server -s -Isrc src/*.c src/eventing/*.c examples/echo_server.c -lssl -lcrypto

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -14,7 +14,7 @@
 #define SETSOCKOPT_PTR_TYPE const char *
 #define LIBUS_SOCKET_ERROR INVALID_SOCKET
 #else
-#define __USE_GNU
+#define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>


### PR DESCRIPTION
The output:

```
alec@alec-MS-7623 ~/product/uSockets (master) $ make
gcc -O3 -DLIBUS_NO_SSL -o echo_server -s -Isrc src/*.c src/eventing/*.c examples/echo_server.c -lssl -lcrypto
In file included from src/internal/common.h:12:0,
                 from src/context.c:2:
src/internal/networking/bsd.h: In function ‘bsd_accept_socket’:
src/internal/networking/bsd.h:88:19: warning: implicit declaration of function ‘accept4’ [-Wimplicit-function-declaration]
     accepted_fd = accept4(fd, 0, 0, SOCK_CLOEXEC | SOCK_NONBLOCK);
                   ^
In file included from src/internal/common.h:12:0,
                 from src/loop.c:2:
src/internal/networking/bsd.h: In function ‘bsd_accept_socket’:
src/internal/networking/bsd.h:88:19: warning: implicit declaration of function ‘accept4’ [-Wimplicit-function-declaration]
     accepted_fd = accept4(fd, 0, 0, SOCK_CLOEXEC | SOCK_NONBLOCK);
                   ^
In file included from src/internal/common.h:12:0,
                 from src/socket.c:2:
src/internal/networking/bsd.h: In function ‘bsd_accept_socket’:
src/internal/networking/bsd.h:88:19: warning: implicit declaration of function ‘accept4’ [-Wimplicit-function-declaration]
     accepted_fd = accept4(fd, 0, 0, SOCK_CLOEXEC | SOCK_NONBLOCK);
                   ^
In file included from src/internal/common.h:12:0,
                 from src/eventing/epoll.c:2:
src/internal/networking/bsd.h: In function ‘bsd_accept_socket’:
src/internal/networking/bsd.h:88:19: warning: implicit declaration of function ‘accept4’ [-Wimplicit-function-declaration]
     accepted_fd = accept4(fd, 0, 0, SOCK_CLOEXEC | SOCK_NONBLOCK);
                   ^
src/eventing/epoll.c: In function ‘us_internal_accept_poll_event’:
src/eventing/epoll.c:99:5: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
     read(fd, &buf, 8);
     ^
src/eventing/epoll.c: In function ‘us_internal_async_wakeup’:
src/eventing/epoll.c:157:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
     write(us_poll_fd((struct us_poll *) a), &one, 8);
     ^
In file included from src/internal/common.h:12:0,
                 from src/eventing/libuv.c:2:
src/internal/networking/bsd.h: In function ‘bsd_accept_socket’:
src/internal/networking/bsd.h:88:19: warning: implicit declaration of function ‘accept4’ [-Wimplicit-function-declaration]
     accepted_fd = accept4(fd, 0, 0, SOCK_CLOEXEC | SOCK_NONBLOCK);
                   ^
alec@alec-MS-7623 ~/product/uSockets (master) $ ./echo_server 
Listening on port 3000
sweeping timers now
sweeping timers now
^C
alec@alec-MS-7623 ~/product/uSockets (master) $ 
```