### PR TITLE
Add support for mutual TLS client certificates

### DIFF
--- a/misc/manual.md
+++ b/misc/manual.md
@@ -106,6 +106,7 @@ struct us_ssl_socket_context_options {
     const char *key_file_name;
     const char *cert_file_name;
     const char *passphrase;
+    const char *ca_file_name;
 };
 
 /* See us_create_socket_context. SSL variant taking SSL options structure */

--- a/src/interfaces/ssl.h
+++ b/src/interfaces/ssl.h
@@ -7,6 +7,7 @@ struct us_ssl_socket_context_options {
     const char *key_file_name;
     const char *cert_file_name;
     const char *passphrase;
+    const char *ca_file_name;
     const char *dh_params_file_name;
 };
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -337,6 +337,14 @@ struct us_ssl_socket_context *us_create_ssl_socket_context(struct us_loop *loop,
         }
     }
 
+    if (options.ca_file_name) {
+        if (SSL_CTX_load_verify_locations(context->ssl_context, options.ca_file_name, NULL) != 1){
+            return 0;
+        }
+        SSL_CTX_set_client_CA_list(context->ssl_context, SSL_load_client_CA_file(options.ca_file_name));
+        SSL_CTX_set_verify(context->ssl_context, SSL_VERIFY_PEER, NULL);
+    }
+
     if (options.dh_params_file_name) {
         /* Set up ephemeral DH parameters. */
         DH *dh_2048 = NULL;


### PR DESCRIPTION
Add support for mutual TLS.  When enabled, only allows valid clients, as specified by the provided CA, to connect to the socket.