### PR TITLE
Include netinet/in.h

### DIFF
--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -34,6 +34,7 @@
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
 #include <string.h>


### PR DESCRIPTION
Fixes build error: use of undeclared identifier 'IPPROTO_TCP' on FreeBSD.