### PR TITLE
Allow Disabling SO_REUSEPORT

### DIFF
--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -46,8 +46,6 @@
 #define LIBUS_SOCKET_ERROR -1
 #endif
 
-#define DO_NOT_REUSE_PORT 2 // LIBUS_LISTEN_OPTION_LINUX_REUSE_PORT
-
 static inline LIBUS_SOCKET_DESCRIPTOR apple_no_sigpipe(LIBUS_SOCKET_DESCRIPTOR fd) {
 #ifdef __APPLE__
     if (fd != LIBUS_SOCKET_ERROR) {
@@ -227,7 +225,7 @@ static inline LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host,
 
     /* Always enable SO_REUSEPORT and SO_REUSEADDR _unless_ options specify otherwise */
 #if defined(__linux) && defined(SO_REUSEPORT)
-    if (!(options & DO_NOT_REUSE_PORT)) {
+    if (!(options & OPTION_DO_NOT_REUSE_PORT)) {
         int optval = 1;
         setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
     }

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -46,7 +46,7 @@
 #define LIBUS_SOCKET_ERROR -1
 #endif
 
-#define REUSE_PORT 2 // LIBUS_LISTEN_OPTION_LINUX_REUSE_PORT
+#define DO_NOT_REUSE_PORT 2 // LIBUS_LISTEN_OPTION_LINUX_REUSE_PORT
 
 static inline LIBUS_SOCKET_DESCRIPTOR apple_no_sigpipe(LIBUS_SOCKET_DESCRIPTOR fd) {
 #ifdef __APPLE__
@@ -227,10 +227,10 @@ static inline LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host,
 
     /* Always enable SO_REUSEPORT and SO_REUSEADDR _unless_ options specify otherwise */
 #if defined(__linux) && defined(SO_REUSEPORT)
-    //if (options & REUSE_PORT) {
+    if (!(options & DO_NOT_REUSE_PORT)) {
         int optval = 1;
         setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
-    //}
+    }
 #endif
 
     int enabled = 1;

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -46,7 +46,7 @@ extern "C" {
 
 /* I guess these are listening options */
 enum {
-    OPTION_REUSE_PORT
+    OPTION_DO_NOT_REUSE_PORT
 };
 
 /* Library types publicly available */

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -46,7 +46,7 @@ extern "C" {
 
 /* I guess these are listening options */
 enum {
-    OPTION_DO_NOT_REUSE_PORT
+    OPTION_DO_NOT_REUSE_PORT = 2
 };
 
 /* Library types publicly available */


### PR DESCRIPTION
Per the discussions on https://github.com/uNetworking/uWebSockets.js/issues/118 from @davidmurdoch, this PR adds back the ability to use the options to control SO_REUSEPORT.

However, instead of reinstating the previous option to opt-in, I have altered the code to maintain the opt-out functionality.

Feel free to edit the code directly as you see fit @alexhultman 