### PR TITLE
Macros for more human-readable function arguments

### DIFF
--- a/examples/hammer_test.c
+++ b/examples/hammer_test.c
@@ -227,7 +227,7 @@ struct us_socket_t *on_http_socket_open(struct us_socket_t *s, int is_client, ch
     printf("Opened: %d\nClosed: %d\n\n", opened_connections, closed_connections);
 
     if (is_client && opened_connections <= 10000 - 2) {
-        us_socket_context_connect(SSL, http_context, "127.0.0.1", 3000, 0, sizeof(struct http_socket));
+        us_socket_context_connect(SSL, http_context, "127.0.0.1", 3000, NULL, 0, sizeof(struct http_socket));
     }
 
     return perform_random_operation(s);
@@ -287,7 +287,7 @@ int main() {
 
     if (listen_socket) {
         printf("Running hammer test\n");
-        us_socket_context_connect(SSL, http_context, "127.0.0.1", 3000, 0, sizeof(struct http_socket));
+        us_socket_context_connect(SSL, http_context, "127.0.0.1", 3000, NULL, 0, sizeof(struct http_socket));
         us_loop_run(loop);
     } else {
         printf("Cannot listen to port 3000!\n");

--- a/examples/http_load_test.c
+++ b/examples/http_load_test.c
@@ -73,7 +73,7 @@ struct us_socket_t *on_http_socket_open(struct us_socket_t *s, int is_client, ch
     us_socket_write(SSL, s, request, sizeof(request) - 1, 0);
 
     if (--connections) {
-        us_socket_context_connect(SSL, us_socket_context(SSL, s), host, port, 0, sizeof(struct http_socket));
+        us_socket_context_connect(SSL, us_socket_context(SSL, s), host, port, NULL, 0, sizeof(struct http_socket));
     } else {
         printf("Running benchmark now...\n");
 
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
     us_socket_context_on_end(SSL, http_context, on_http_socket_end);
 
     /* Start making HTTP connections */
-    us_socket_context_connect(SSL, http_context, host, port, 0, sizeof(struct http_socket));
+    us_socket_context_connect(SSL, http_context, host, port, NULL, 0, sizeof(struct http_socket));
 
     us_loop_run(loop);
 }

--- a/examples/peer_verify_test.c
+++ b/examples/peer_verify_test.c
@@ -246,7 +246,7 @@ int expect_peer_verify(const char *test_name, bool expect_data_exchanged,
     us_socket_context_on_timeout(SSL, client_context, on_client_socket_timeout);
     us_socket_context_on_end(SSL, client_context, on_client_socket_end);
 
-    us_socket_context_connect(SSL, client_context, "127.0.0.1", port, 0, sizeof(struct socket_context));
+    us_socket_context_connect(SSL, client_context, "127.0.0.1", port, NULL, 0, sizeof(struct socket_context));
     us_loop_run(loop);
 
     us_socket_context_free(SSL, server_context);

--- a/examples/self_scale.c
+++ b/examples/self_scale.c
@@ -1,0 +1,229 @@
+/* This is a self scalability test for testing million(s) of connections and their memory consumption */
+
+#include <libusockets.h>
+int SSL;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+unsigned char web_socket_request[26] = {130, 128 | 20, 1, 2, 3, 4};
+
+char request[] = "GET / HTTP/1.1\r\n"
+                 "Upgrade: websocket\r\n"
+                 "Connection: Upgrade\r\n"
+                 "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n"
+                 "Host: server.example.com\r\n"
+                 "Sec-WebSocket-Version: 13\r\n\r\n";
+char *host;
+int port;
+int connections;
+
+/* Send ping every 16 seconds */
+int WEBSOCKET_PING_INTERVAL = 48;
+
+/* We only establish 20k connections per address */
+int CONNECTIONS_PER_ADDRESS = 20000;
+
+/* How many connections a time */
+int BATCH_CONNECT = 1;
+
+/* Currently open and alive connections */
+int opened_connections;
+/* Dead connections */
+int closed_connections;
+
+struct http_socket {
+    /* How far we have streamed our websocket request */
+    int offset;
+
+    /* How far we have streamed our upgrade request */
+    int upgrade_offset;
+};
+
+/* We don't need any of these */
+void on_wakeup(struct us_loop_t *loop) {
+
+}
+
+void on_pre(struct us_loop_t *loop) {
+
+}
+
+/* This is not HTTP POST, it is merely an event emitted post loop iteration */
+void on_post(struct us_loop_t *loop) {
+
+}
+
+void next_connection(struct us_socket_t *s) {
+    /* We could wait with this until properly upgraded */
+    if (--connections/* > BATCH_CONNECT*/) {
+        /* Swap address */
+        int address = opened_connections / CONNECTIONS_PER_ADDRESS + 1;
+        char buf[32];
+        sprintf(buf, "127.0.0.%d", address);
+
+        us_socket_context_connect(SSL, us_socket_context(SSL, s), "127.0.0.1", port, buf, 0, sizeof(struct http_socket));
+    }
+}
+
+struct us_socket_t *on_http_socket_writable(struct us_socket_t *s) {
+    struct http_socket *http_socket = (struct http_socket *) us_socket_ext(SSL, s);
+
+    /* Are we still not upgraded yet? */
+    if (http_socket->upgrade_offset < sizeof(request) - 1) {
+        http_socket->upgrade_offset += us_socket_write(SSL, s, request + http_socket->upgrade_offset, sizeof(request) - 1 - http_socket->upgrade_offset, 0);
+
+        /* Now we should be */
+        if (http_socket->upgrade_offset == sizeof(request) - 1) {
+            next_connection(s);
+
+            /* Make sure to send ping */
+            us_socket_timeout(SSL, s, WEBSOCKET_PING_INTERVAL);
+        }
+    } else {
+        /* Stream whatever is remaining of the request */
+        http_socket->offset += us_socket_write(SSL, s, (char *) web_socket_request + http_socket->offset, sizeof(web_socket_request) - http_socket->offset, 0);
+        if (http_socket->offset == sizeof(web_socket_request)) {
+            /* Reset timeout if we managed to */
+            us_socket_timeout(SSL, s, WEBSOCKET_PING_INTERVAL);
+        }
+    }
+
+    return s;
+}
+
+struct us_socket_t *on_http_socket_close(struct us_socket_t *s) {
+
+    closed_connections++;
+    if (closed_connections % 1000 == 0) {
+        printf("Alive: %d, dead: %d\n", opened_connections, closed_connections);
+    }
+
+    return s;
+}
+
+struct us_socket_t *on_http_socket_end(struct us_socket_t *s) {
+    return us_socket_close(SSL, s);
+}
+
+// should never get a response!
+struct us_socket_t *on_http_socket_data(struct us_socket_t *s, char *data, int length) {
+    return s;
+}
+
+struct us_socket_t *on_http_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {
+    struct http_socket *http_socket = (struct http_socket *) us_socket_ext(SSL, s);
+
+    /* Display number of opened connections */
+    opened_connections++;
+    if (opened_connections % 1000 == 0) {
+        printf("Alive: %d, dead: %d\n", opened_connections, closed_connections);
+    }
+
+    /* Send an upgrade request */
+    http_socket->upgrade_offset = us_socket_write(SSL, s, request, sizeof(request) - 1, 0);
+    if (http_socket->upgrade_offset == sizeof(request) - 1) {
+        next_connection(s);
+
+        /* Make sure to send ping */
+        us_socket_timeout(SSL, s, WEBSOCKET_PING_INTERVAL);
+    }
+
+    return s;
+}
+
+// here we should send a message as ping (part of the test)
+struct us_socket_t *on_http_socket_timeout(struct us_socket_t *s) {
+    struct http_socket *http_socket = (struct http_socket *) us_socket_ext(SSL, s);
+
+    /* Send ping here */
+    http_socket->offset = us_socket_write(SSL, s, (char *) web_socket_request, sizeof(web_socket_request), 0);
+    if (http_socket->offset == sizeof(web_socket_request)) {
+        /* Reset timeout if we managed to */
+        us_socket_timeout(SSL, s, WEBSOCKET_PING_INTERVAL);
+    }
+
+    return s;
+}
+
+struct us_socket_t *on_server_socket_writable(struct us_socket_t *s) {
+    return s;
+}
+
+struct us_socket_t *on_server_socket_close(struct us_socket_t *s) {
+    return s;
+}
+
+struct us_socket_t *on_server_socket_end(struct us_socket_t *s) {
+    return us_socket_close(SSL, s);
+}
+
+struct us_socket_t *on_server_socket_data(struct us_socket_t *s, char *data, int length) {
+    return s;
+}
+
+struct us_socket_t *on_server_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {
+    return s;
+}
+
+struct us_socket_t *on_server_socket_timeout(struct us_socket_t *s) {
+    return s;
+}
+
+int main(int argc, char **argv) {
+
+    /* Parse host and port */
+    if (argc != 5) {
+        printf("Usage: connections host port ssl\n");
+        return 0;
+    }
+
+    port = atoi(argv[3]);
+    host = malloc(strlen(argv[2]) + 1);
+    memcpy(host, argv[2], strlen(argv[2]) + 1);
+    connections = atoi(argv[1]);
+    SSL = atoi(argv[4]);
+
+    /* Create the event loop */
+    struct us_loop_t *loop = us_create_loop(0, on_wakeup, on_pre, on_post, 0);
+
+    /* Create a socket context for HTTP */
+    struct us_socket_context_options_t options = {};
+    struct us_socket_context_t *http_context = us_create_socket_context(SSL, loop, 0, options);
+
+    /* Set up event handlers */
+    us_socket_context_on_open(SSL, http_context, on_http_socket_open);
+    us_socket_context_on_data(SSL, http_context, on_http_socket_data);
+    us_socket_context_on_writable(SSL, http_context, on_http_socket_writable);
+    us_socket_context_on_close(SSL, http_context, on_http_socket_close);
+    us_socket_context_on_timeout(SSL, http_context, on_http_socket_timeout);
+    us_socket_context_on_end(SSL, http_context, on_http_socket_end);
+
+    /* Create server socket context */
+    struct us_socket_context_t *server_context = us_create_socket_context(SSL, loop, 0, options);
+
+    /* Set up server event handlers */
+    us_socket_context_on_open(SSL, server_context, on_server_socket_open);
+    us_socket_context_on_data(SSL, server_context, on_server_socket_data);
+    us_socket_context_on_writable(SSL, server_context, on_server_socket_writable);
+    us_socket_context_on_close(SSL, server_context, on_server_socket_close);
+    us_socket_context_on_timeout(SSL, server_context, on_server_socket_timeout);
+    us_socket_context_on_end(SSL, server_context, on_server_socket_end);
+
+    /* Listen for connections */
+    struct us_listen_socket_t *listen_socket = us_socket_context_listen(SSL, server_context, 0, 3000, 0, sizeof(struct http_socket));
+
+    if (listen_socket) {
+	printf("Listening on port 3000...\n");
+    } else {
+	printf("Failed to listen!\n");
+    }
+
+    /* Start making HTTP connections */
+    for (int i = 0; i < BATCH_CONNECT; i++) {
+        us_socket_context_connect(SSL, http_context, host, port, "127.0.0.1", 0, sizeof(struct http_socket));
+    }
+
+    us_loop_run(loop);
+}

--- a/src/context.c
+++ b/src/context.c
@@ -167,14 +167,14 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
     return ls;
 }
 
-struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, int options, int socket_ext_size) {
+struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, const char *interface, int options, int socket_ext_size) {
 #ifndef LIBUS_NO_SSL
     if (ssl) {
-        return (struct us_socket_t *) us_internal_ssl_socket_context_connect((struct us_internal_ssl_socket_context_t *) context, host, port, options, socket_ext_size);
+        return (struct us_socket_t *) us_internal_ssl_socket_context_connect((struct us_internal_ssl_socket_context_t *) context, host, port, interface, options, socket_ext_size);
     }
 #endif
 
-    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(host, port, options);
+    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(host, port, interface, options);
     if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -483,8 +483,8 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     return us_socket_context_listen(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
-struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, int options, int socket_ext_size) {
-    return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *interface, int options, int socket_ext_size) {
+    return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, interface, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
 void us_internal_ssl_socket_context_on_open(struct us_internal_ssl_socket_context_t *context, struct us_internal_ssl_socket_t *(*on_open)(struct us_internal_ssl_socket_t *s, int is_client, char *ip, int ip_length)) {

--- a/src/crypto/wolfssl.c
+++ b/src/crypto/wolfssl.c
@@ -423,8 +423,8 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     return us_socket_context_listen(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
-struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, int options, int socket_ext_size) {
-    return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *interface, int options, int socket_ext_size) {
+    return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, interface, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
 void us_internal_ssl_socket_context_on_open(struct us_internal_ssl_socket_context_t *context, struct us_internal_ssl_socket_t *(*on_open)(struct us_internal_ssl_socket_t *s, int is_client, char *ip, int ip_length)) {

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -150,7 +150,7 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     const char *host, int port, int options, int socket_ext_size);
 
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context,
-    const char *host, int port, int options, int socket_ext_size);
+    const char *host, int port, const char *interface, int options, int socket_ext_size);
 
 int us_internal_ssl_socket_write(struct us_internal_ssl_socket_t *s, const char *data, int length, int msg_more);
 void us_internal_ssl_socket_timeout(struct us_internal_ssl_socket_t *s, unsigned int seconds);

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -87,6 +87,17 @@ static inline LIBUS_SOCKET_DESCRIPTOR bsd_create_socket(int domain, int type, in
 
     LIBUS_SOCKET_DESCRIPTOR created_fd = socket(domain, type | flags, protocol);
 
+    // set buffers to smallest possible
+    int a = 128;
+    if (setsockopt(created_fd, SOL_SOCKET, SO_RCVBUF, &a, sizeof(int)) == -1) {
+        fprintf(stderr, "Error setting socket opts: %s\n", strerror(errno));
+    }
+
+    a = 1024;
+    if (setsockopt(created_fd, SOL_SOCKET, SO_SNDBUF, &a, sizeof(int)) == -1) {
+        fprintf(stderr, "Error setting socket opts: %s\n", strerror(errno));
+    }
+
     return bsd_set_nonblocking(apple_no_sigpipe(created_fd));
 }
 

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -27,6 +27,22 @@
 /* Guaranteed alignment of extension memory */
 #define LIBUS_EXT_ALIGNMENT 16
 
+
+/* Macros to make function arguments more human-readable */
+
+// uSockets: Don't use SSL.
+#define uS_NO_SSL false
+// uSockets: Use SSL.
+#define uS_WITH_SSL true
+// uSockets: Don't use a context extension.
+#define uS_NO_EXTENSION 0
+// uSockets: Use this context extension (passes sizeof).
+#define uS_WITH_EXTENSION(ext) sizeof(ext)
+// uSockets: Don't give the us_socket_context_options_t to the socket.
+#define uS_NO_SSL_OPTIONS 0
+// uSockets: Give the us_socket_context_options_t to the socket.
+#define uS_WITH_SSL_OPTIONS 1
+
 /* Define what a socket descriptor is based on platform */
 #ifdef _WIN32
 #define NOMINMAX

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -121,7 +121,7 @@ WIN32_EXPORT void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls)
 
 /* Land in on_open or on_close or return null or return socket */
 WIN32_EXPORT struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context,
-    const char *host, int port, int options, int socket_ext_size);
+    const char *host, int port, const char *interface, int options, int socket_ext_size);
 
 /* Returns the loop for this socket context. */
 WIN32_EXPORT struct us_loop_t *us_socket_context_loop(int ssl, struct us_socket_context_t *context);


### PR DESCRIPTION
These are macros that I use to make the usockets function arguments more human-readable. Instead of a bunch of zeros, we have descriptive arguments.

For example,

```
example = us_socket_context_listen(0, socket_context, "127.0.0.1", 1000, 0, sizeof(MyExtension));
// becomes:
example = us_socket_context_listen(uS_NO_SSL, socket_context, "127.0.0.1", 1000, uS_NO_SSL_OPTIONS, uS_WITH_EXTENSION(MyExtension));
```

I prefixed uS_ to avoid name conflicts. This does make the code a bit longer, but I think it's very much worth it. Please let me know if I have misinterpreted what the arguments mean; I'll need to fix that in my project at least.