### PR TITLE
option to disable lto, enabled by default to avoid regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+WITH_LTO := $(or $(WITH_LTO),-flto)
 # WITH_OPENSSL=1 enables OpenSSL 1.1+ support
 ifeq ($(WITH_OPENSSL),1)
 	override CFLAGS += -DLIBUS_USE_OPENSSL
@@ -38,13 +39,13 @@ override LDFLAGS += uSockets.a
 # By default we build the uSockets.a static library
 default:
 	rm -f *.o
-	$(CC) $(CFLAGS) -flto -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
+	$(CC) $(CFLAGS) $(WITH_LTO) -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
 	$(AR) rvs uSockets.a *.o
 
 # Builds all examples
 .PHONY: examples
 examples: default
-	for f in examples/*.c; do $(CC) -flto -O3 $(CFLAGS) -o $$(basename "$$f" ".c") "$$f" $(LDFLAGS); done
+	for f in examples/*.c; do $(CC) $(WITH_LTO) -O3 $(CFLAGS) -o $$(basename "$$f" ".c") "$$f" $(LDFLAGS); done
 
 swift_examples:
 	swiftc -O -I . examples/swift_http_server/main.swift uSockets.a -o swift_http_server


### PR DESCRIPTION
Trying to build static executable in linux using clang, but certain third party libraries are gcc compiled and running into random issues related to LTO issues(undefined reference). this flag will provide option to disable lto if not required. 

Steps to reproduce: (With in new factory installed redhat 8 container) 

da09 ➜  ~ docker pull centos
da09 ➜  ~ docker run -it --rm centos  
[root@05386def3fe3 /]# yum update && yum group install "Development Tools"
[root@05386def3fe3 /]# git clone https://github.com/uNetworking/uSockets
[root@05386def3fe3 /]# cd uSockets/
[root@05386def3fe3 uSockets]# make examples
rm -f *.o
cc -DLIBUS_NO_SSL -std=c11 -Isrc -flto -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
ar rvs uSockets.a *.o
ar: creating uSockets.a
a - context.o
a - epoll_kqueue.o
a - gcd.o
a - libuv.o
a - loop.o
a - openssl.o
a - socket.o
a - wolfssl.o
ar: context.o: plugin needed to handle lto object
ar: epoll_kqueue.o: plugin needed to handle lto object
ar: gcd.o: plugin needed to handle lto object
ar: libuv.o: plugin needed to handle lto object
ar: loop.o: plugin needed to handle lto object
ar: openssl.o: plugin needed to handle lto object
ar: socket.o: plugin needed to handle lto object
ar: wolfssl.o: plugin needed to handle lto object
for f in examples/*.c; do cc -flto -O3 -DLIBUS_NO_SSL -std=c11 -Isrc -o $(basename "$f" ".c") "$f" uSockets.a; done
/tmp/ccAd3JMz.ltrans0.ltrans.o: In function `on_echo_socket_open':
<artificial>:(.text+0x3d): undefined reference to `us_socket_ext'
<artificial>:(.text+0x5d): undefined reference to `us_socket_timeout'
