### PR TITLE
Implemented low-priority queue for new SSL connections

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int default_ignore_data_handler(struct us_socket_t *s) {
+int default_is_low_prio_handler(struct us_socket_t *s) {
     return 0;
 }
 
@@ -71,7 +71,6 @@ void us_internal_socket_context_unlink(struct us_socket_context_t *context, stru
 /* We always add in the top, so we don't modify any s.next */
 void us_internal_socket_context_link(struct us_socket_context_t *context, struct us_socket_t *s) {
     s->context = context;
-    s->timeout = 0;
     s->next = context->head;
     s->prev = 0;
     if (context->head) {
@@ -147,7 +146,7 @@ struct us_socket_context_t *us_create_socket_context(int ssl, struct us_loop_t *
     context->head = 0;
     context->iterator = 0;
     context->next = 0;
-    context->ignore_data = default_ignore_data_handler;
+    context->is_low_prio = default_is_low_prio_handler;
 
     /* Begin at 0 */
     context->timestamp = 0;
@@ -195,6 +194,7 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
 
     ls->s.context = context;
     ls->s.timeout = 0;
+    ls->s.low_prio_state = 0;
     ls->s.next = 0;
     us_internal_socket_context_link(context, &ls->s);
 
@@ -224,6 +224,8 @@ struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_
 
     /* Link it into context so that timeout fires properly */
     connect_socket->context = context;
+    connect_socket->timeout = 0;
+    connect_socket->low_prio_state = 0;
     us_internal_socket_context_link(context, connect_socket);
 
     return connect_socket;
@@ -254,12 +256,23 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
         return s;
     }
 
-    /* This properly updates the iterator if in on_timeout */
-    us_internal_socket_context_unlink(s->context, s);
+    if (s->low_prio_state != 1) {
+        /* This properly updates the iterator if in on_timeout */
+        us_internal_socket_context_unlink(s->context, s);
+    }
 
     struct us_socket_t *new_s = (struct us_socket_t *) us_poll_resize(&s->p, s->context->loop, sizeof(struct us_socket_t) + ext_size);
+    new_s->timeout = 0;
 
-    us_internal_socket_context_link(context, new_s);
+    if (new_s->low_prio_state == 1) {
+        /* update pointers in low-priority queue */
+        if (!new_s->prev) new_s->context->loop->data.low_prio_head = new_s;
+        else new_s->prev->next = new_s;
+
+        if (new_s->next) new_s->next->prev = new_s;
+    } else {
+        us_internal_socket_context_link(context, new_s);
+    }
 
     return new_s;
 }

--- a/src/crypto/wolfssl.c
+++ b/src/crypto/wolfssl.c
@@ -29,11 +29,6 @@
 #define OPENSSL_init_ssl(a, b) wolfSSL_Init()
 #define SSL_in_init(x) (!wolfSSL_is_init_finished(x))
 
-/* We do not want to block the loop with tons and tons of CPU-intensive work.
- * Spread it out during many loop iterations, prioritizing already open connections,
- * they are far easier on CPU */
-static const int MAX_HANDSHAKES_PER_LOOP_ITERATION = 5;
-
 struct loop_ssl_data {
     char *ssl_read_input, *ssl_read_output;
     unsigned int ssl_read_input_length;
@@ -42,10 +37,6 @@ struct loop_ssl_data {
 
     int last_write_was_msg_more;
     int msg_more;
-
-    // these are used to throttle SSL handshakes per loop iteration
-    long long last_iteration_nr;
-    int handshake_budget;
 };
 
 struct us_internal_ssl_socket_context_t {
@@ -252,10 +243,6 @@ void us_internal_init_loop_ssl_data(struct us_loop_t *loop) {
 
         OPENSSL_init_ssl(0, NULL);
 
-        // reset handshake budget (doesn't matter what loop nr we start on)
-        loop_ssl_data->last_iteration_nr = 0;
-        loop_ssl_data->handshake_budget = MAX_HANDSHAKES_PER_LOOP_ITERATION;
-
         loop->data.ssl_data = loop_ssl_data;
     }
 }
@@ -271,35 +258,10 @@ void us_internal_free_loop_ssl_data(struct us_loop_t *loop) {
     }
 }
 
-// we ignore reading data for ssl sockets that are
-// in init state, if our so called budget for doing
-// so won't allow it. here we actually use
+// we throttle reading data for ssl sockets that are in init state. here we actually use
 // the kernel buffering to our advantage
-int ssl_ignore_data(struct us_internal_ssl_socket_t *s) {
-
-    // fast path just checks for init
-    if (!SSL_in_init(s->ssl)) {
-        return 0;
-    }
-
-    // this path is run for all ssl sockets that are in init and just got data event from polling
-
-    struct us_loop_t *loop = s->s.context->loop;
-    struct loop_ssl_data *loop_ssl_data = loop->data.ssl_data;
-
-    // reset handshake budget if new iteration
-    if (loop_ssl_data->last_iteration_nr != us_loop_iteration_number(loop)) {
-        loop_ssl_data->last_iteration_nr = us_loop_iteration_number(loop);
-        loop_ssl_data->handshake_budget = MAX_HANDSHAKES_PER_LOOP_ITERATION;
-    }
-
-    if (loop_ssl_data->handshake_budget) {
-        loop_ssl_data->handshake_budget--;
-        return 0;
-    }
-
-    // ignore this data event
-    return 1;
+int ssl_is_low_prio(struct us_internal_ssl_socket_t *s) {
+    return SSL_in_init(s->ssl);
 }
 
 /* Per-context functions */
@@ -361,7 +323,7 @@ struct us_internal_ssl_socket_context_t *us_internal_create_ssl_socket_context(s
     context->ssl_context = wolfSSL_CTX_new(wolfTLSv1_2_server_method());
     context->is_parent = 1;
     // only parent ssl contexts may need to ignore data
-    context->sc.ignore_data = (int (*)(struct us_socket_t *)) ssl_ignore_data;
+    context->sc.is_low_prio = (int (*)(struct us_socket_t *)) ssl_is_low_prio;
 
     wolfSSL_CTX_SetIORecv(context->ssl_context, UserReceive);
     wolfSSL_CTX_SetIOSend(context->ssl_context, UserSend);

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -87,7 +87,8 @@ struct us_socket_t {
     alignas(LIBUS_EXT_ALIGNMENT) struct us_poll_t p;
     struct us_socket_context_t *context;
     struct us_socket_t *prev, *next;
-    unsigned short timeout;
+    unsigned short timeout : 14;
+    unsigned short low_prio_state : 2; /* 0 = not in low-prio queue, 1 = is in low-prio queue, 2 = was in low-prio queue in this iteration */
 };
 
 /* Internal callback types are polls just like sockets */
@@ -119,7 +120,7 @@ struct us_socket_context_t {
     struct us_socket_t *(*on_socket_timeout)(struct us_socket_t *);
     struct us_socket_t *(*on_end)(struct us_socket_t *);
     struct us_socket_t *(*on_connect_error)(struct us_socket_t *, int code);
-    int (*ignore_data)(struct us_socket_t *);
+    int (*is_low_prio)(struct us_socket_t *);
 };
 
 /* Internal SSL interface */

--- a/src/internal/loop_data.h
+++ b/src/internal/loop_data.h
@@ -29,6 +29,8 @@ struct us_internal_loop_data_t {
     void (*pre_cb)(struct us_loop_t *);
     void (*post_cb)(struct us_loop_t *);
     struct us_socket_t *closed_head;
+    struct us_socket_t *low_prio_head;
+    int low_prio_budget;
     /* We do not care if this flips or not, it doesn't matter */
     long long iteration_nr;
 };


### PR DESCRIPTION
- renamed ignore_data -> is_low_prio
- moved budget handling from loop_ssl_data to us_internal_loop_data_t
- new flag "low_prio_state" per socket (stolen 2 bits from "timeout")
- moved timeout reset outside of us_internal_socket_context_link()

see #96