### PR TITLE
Respect `LIBUS_LISTEN_EXCLUSIVE_PORT` on Windows

### DIFF
--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -242,8 +242,10 @@ static inline LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host,
     }
 #endif
 
+if (!(options & LIBUS_LISTEN_EXCLUSIVE_PORT)) {
     int enabled = 1;
     setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, (SETSOCKOPT_PTR_TYPE) &enabled, sizeof(enabled));
+}
 
 #ifdef IPV6_V6ONLY
     int disabled = 0;


### PR DESCRIPTION
Windows doesn't have `SO_REUSEPORT`, but it _does_ have `SO_REUSEADDR`.

Without setting `SO_REUSEADDR` the socket won't be bound if the port has previously been bound on the _same_ address, so it's not quite the same as setting `SO_REUSEPORT`, but it gets closer.

Not currently included in this PR, but I can add it if you want: if `SO_EXCLUSIVEADDRUSE` is set on Windows when `LIBUS_LISTEN_EXCLUSIVE_PORT` is enabled `uSockets` behavior would more closely align with Linux's. The `SO_EXCLUSIVEADDRUSE` option prevents other sockets from being forcibly bound to the same address and port, a practice enabled by the `SO_REUSEADDR` option. [SO_EXCLUSIVEADDRUSE Docs](https://docs.microsoft.com/en-us/windows/win32/winsock/so-exclusiveaddruse)