### PR TITLE
Fix compilation with mingw: Use lower-case includes

### DIFF
--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -25,8 +25,8 @@
 
 #ifdef _WIN32
 #define NOMINMAX
-#include <WinSock2.h>
-#include <Ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #pragma comment(lib, "ws2_32.lib")
 #include <stdio.h>
 #define SETSOCKOPT_PTR_TYPE const char *

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -30,7 +30,7 @@
 /* Define what a socket descriptor is based on platform */
 #ifdef _WIN32
 #define NOMINMAX
-#include <WinSock2.h>
+#include <winsock2.h>
 #define LIBUS_SOCKET_DESCRIPTOR SOCKET
 #define WIN32_EXPORT __declspec(dllexport)
 #define alignas(x) __declspec(align(x))


### PR DESCRIPTION
Compiling for Windows on linux using mingw fails because of the
capitalization in the Windows header includes (mingw provides only
lower-case ones).  (Windows compilers on windows won't care about the
case at all.)