### PR TITLE
Mingw alignas fix

### DIFF
--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -18,6 +18,12 @@
 #ifndef INTERNAL_H
 #define INTERNAL_H
 
+#if defined(_MSC_VER)
+#define alignas(x) __declspec(align(x))
+#else
+#include <stdalign.h>
+#endif
+
 /* We only have one networking implementation so far */
 #include "internal/networking/bsd.h"
 

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -29,7 +29,9 @@
 
 /* Define what a socket descriptor is based on platform */
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <winsock2.h>
 #define LIBUS_SOCKET_DESCRIPTOR SOCKET
 #define WIN32_EXPORT __declspec(dllexport)

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -33,9 +33,7 @@
 #include <winsock2.h>
 #define LIBUS_SOCKET_DESCRIPTOR SOCKET
 #define WIN32_EXPORT __declspec(dllexport)
-#define alignas(x) __declspec(align(x))
 #else
-#include <stdalign.h>
 #define LIBUS_SOCKET_DESCRIPTOR int
 #define WIN32_EXPORT
 #endif


### PR DESCRIPTION
Fixes a mingw error with `alignas()` (which doesn't like the MSVC alignment macro), and silences a redefinition warning.

With these (and the already merged #114 plus a static libuv also built mingw) I'm able to build and run the built examples under both wine and a real Windows system.