### PR TITLE
Add support for ephemeral ports

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -252,8 +252,8 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
             setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
         }
 #endif
-      int enabled = 1;
-      setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, (SETSOCKOPT_PTR_TYPE) &enabled, sizeof(enabled));
+        int enabled = 1;
+        setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, (SETSOCKOPT_PTR_TYPE) &enabled, sizeof(enabled));
     }
     
 #ifdef IPV6_V6ONLY

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -45,6 +45,7 @@ struct bsd_addr_t {
     socklen_t len;
     char *ip;
     int ip_length;
+    int port;
 };
 
 LIBUS_SOCKET_DESCRIPTOR apple_no_sigpipe(LIBUS_SOCKET_DESCRIPTOR fd);
@@ -58,11 +59,13 @@ void bsd_shutdown_socket(LIBUS_SOCKET_DESCRIPTOR fd);
 
 void internal_finalize_bsd_addr(struct bsd_addr_t *addr);
 
-int bsd_socket_addr(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);
+int bsd_local_addr(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);
+int bsd_remote_addr(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);
 
 char *bsd_addr_get_ip(struct bsd_addr_t *addr);
-
 int bsd_addr_get_ip_length(struct bsd_addr_t *addr);
+
+int bsd_addr_get_port(struct bsd_addr_t *addr);
 
 // called by dispatch_ready_poll
 LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -231,6 +231,9 @@ WIN32_EXPORT int us_socket_is_closed(int ssl, struct us_socket_t *s);
 /* Immediately closes the socket */
 WIN32_EXPORT struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, void *reason);
 
+/* Returns local port or -1 on failure. */
+WIN32_EXPORT int us_socket_local_port(int ssl, struct us_socket_t *s);
+
 /* Copy remote (IP) address of socket, or fail with zero length. */
 WIN32_EXPORT void us_socket_remote_address(int ssl, struct us_socket_t *s, char *buf, int *length);
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -22,9 +22,18 @@
 
 /* Shared with SSL */
 
+int us_socket_local_port(int ssl, struct us_socket_t *s) {
+    struct bsd_addr_t addr;
+    if (bsd_local_addr(us_poll_fd(&s->p), &addr)) {
+      return -1;
+    } else {
+      return bsd_addr_get_port(&addr);
+    }
+}
+
 void us_socket_remote_address(int ssl, struct us_socket_t *s, char *buf, int *length) {
     struct bsd_addr_t addr;
-    if (bsd_socket_addr(us_poll_fd(&s->p), &addr) || *length < bsd_addr_get_ip_length(&addr)) {
+    if (bsd_remote_addr(us_poll_fd(&s->p), &addr) || *length < bsd_addr_get_ip_length(&addr)) {
         *length = 0;
     } else {
         *length = bsd_addr_get_ip_length(&addr);


### PR DESCRIPTION
This is an implementation of the feature described in issue #135.

I wasn't sure about a couple of things. First I debated whether to add the _port_ field to _bsd_addr_t_ or just have _bsd_addr_get_port()_ pull it out of _sockaddr_in_. Both ways worked but adding _port_ to _bsd_addr_t_ seemed more consistent.

The other thing was I changed the name of _bsd_socket_addr()_ to _bsd_remote_addr()_ to better distinguish it from the new _bsd_local_addr()_.

I believe neither _bsd_addr_t_ nor _bsd_socket_addr()_ are part of the public interface so hopefully nothing breaks.

The motivation for preventing SO_REUSEADDR for ephemeral ports is covered by this:
https://gavv.github.io/articles/ephemeral-port-reuse/

I also don't think SO_REUSEPORT with ephemeral ports has any application and it's probably dangerous so I disabled that too.