### PR TITLE
MacOS seems to require SO_REUSEPORT just like Linux.

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -221,7 +221,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
     }
 
     /* Always enable SO_REUSEPORT and SO_REUSEADDR _unless_ options specify otherwise */
-#if defined(__linux) && defined(SO_REUSEPORT)
+#if (defined(__linux) || defined(__APPLE__)) && defined(SO_REUSEPORT)
     if (!(options & LIBUS_LISTEN_EXCLUSIVE_PORT)) {
         int optval = 1;
         setsockopt(listenFd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));


### PR DESCRIPTION
Hello,

I have tried running multiple threads as you describe in the docs, but without this change, it wasn't willing to do it on my Mac.

I don't know if this is a change in how MacOS works, or it was always the case that uWebsockets only worked on 1 thread.

Let me know what you think about adding this little change.
Thank you,
Baldvin