### PR TITLE
Fixes #1306 - transitive dependencies in header files

### DIFF
--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -23,6 +23,8 @@
 // holds everything you need from the bsd/winsock interfaces, only included by internal libusockets.h
 // here everything about the syscalls are inline-wrapped and included
 
+#include "libusockets.h"
+
 #ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX


### PR DESCRIPTION
* uSockets/src/internal/networking/bsd.h
\#include "libusockets.h" for LIBUS_SOCKET_DESCRIPTOR