### PR TITLE
Allow passing custom ciphers via options

### DIFF
--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -516,6 +516,13 @@ SSL_CTX *create_ssl_context_from_options(struct us_socket_context_options_t opti
         }
     }
 
+    if (options.ssl_ciphers) {
+        if (SSL_CTX_set_cipher_list(ssl_context, options.ssl_ciphers) != 1) {
+            free_ssl_context(ssl_context);
+            return NULL;
+        }
+    }
+
     /* This must be free'd with free_ssl_context, not SSL_CTX_free */
     return ssl_context;
 }


### PR DESCRIPTION
The main goal is to be able to pass custom ciphers from node.js (In App options) and have them used internally in uSockets

Required for https://github.com/uNetworking/uWebSockets/pull/1435 & https://github.com/uNetworking/uWebSockets.js/pull/723