### PR TITLE
Add Unix Domain Socket listening

### DIFF
--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -657,6 +657,12 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     return us_socket_context_listen(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
+#ifdef __linux__
+struct us_listen_socket_t *us_internal_ssl_socket_context_unix_listen(struct us_internal_ssl_socket_context_t *context, const char *path, int options, int socket_ext_size) {
+    return us_socket_context_unix_listen(0, &context->sc, path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+}
+#endif
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
     return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, source_host, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }

--- a/src/crypto/wolfssl.c
+++ b/src/crypto/wolfssl.c
@@ -385,6 +385,12 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     return us_socket_context_listen(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
+#ifdef __linux__
+struct us_listen_socket_t *us_internal_ssl_socket_context_unix_listen(struct us_internal_ssl_socket_context_t *context, const char *path, int options, int socket_ext_size) {
+    return us_socket_context_listen(0, &context->sc, path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+}
+#endif
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
     return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, source_host, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -169,6 +169,11 @@ void us_internal_ssl_socket_context_on_connect_error(struct us_internal_ssl_sock
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, int options, int socket_ext_size);
 
+#ifdef __linux__
+struct us_listen_socket_t *us_internal_ssl_socket_context_unix_listen(struct us_internal_ssl_socket_context_t *context,
+    const char *path, int options, int socket_ext_size);
+#endif
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);
 

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -92,6 +92,12 @@ int bsd_would_block();
 // listen both on ipv6 and ipv4
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options);
 
+#ifdef __linux__
+// return LIBUS_SOCKET_ERROR or the fd that represents listen socket
+// listen unix domain socket
+LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_listen_socket(const char * path, int options);
+#endif
+
 /* Creates an UDP socket bound to the hostname and port */
 LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port);
 

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -169,6 +169,14 @@ WIN32_EXPORT void *us_socket_context_ext(int ssl, struct us_socket_context_t *co
 WIN32_EXPORT struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_context_t *context,
     const char *host, int port, int options, int socket_ext_size);
 
+#ifdef __linux__
+/* Listen for connections on unix port. Acts as the main driving cog in a server. Will call set async callbacks. 
+ * Accepts path as a pathname socket (path on filesystem) or abstract socket (starts with null character), second null character ends the path.
+ * See `sockaddr_un.sun_path` for details. */
+WIN32_EXPORT struct us_listen_socket_t *us_socket_context_unix_listen(int ssl, struct us_socket_context_t *context,
+    const char *path, int options, int socket_ext_size);
+#endif
+
 /* listen_socket.c/.h */
 WIN32_EXPORT void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);
 


### PR DESCRIPTION
Allows listening to unix domain sockets over tcp. Does not implement connecting to a unix domain socket as a client or udp.

I happened to want this for a project I was working on and saw #15, so I decided to finish the changes and submit a PR.