### PR TITLE
add unix domain socket for both server and client side

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,7 +19,7 @@ jobs:
     - name: build examples
       run: WITH_LIBUV=1 WITH_ASAN=1 make examples
     - name: run test
-      run: ./hammer_test
+      run: ./hammer_test && ./hammer_test_unix
 
   test_macos_kqueue:
 
@@ -30,8 +30,8 @@ jobs:
     - name: build examples
       run: WITH_ASAN=1 make examples
     - name: run test
-      run: ./hammer_test
-      
+      run: ./hammer_test && ./hammer_test_unix
+
   test_linux_libuv:
 
     runs-on: ubuntu-latest
@@ -43,8 +43,8 @@ jobs:
     - name: build examples
       run: WITH_LIBUV=1 WITH_ASAN=1 make examples
     - name: run test
-      run: ./hammer_test
-      
+      run: ./hammer_test && ./hammer_test_unix
+
   test_linux_epoll:
 
     runs-on: ubuntu-latest
@@ -54,4 +54,4 @@ jobs:
     - name: build examples
       run: WITH_ASAN=1 make examples
     - name: run test
-      run: ./hammer_test
+      run: ./hammer_test && ./hammer_test_unix

--- a/examples/echo_server.c
+++ b/examples/echo_server.c
@@ -105,7 +105,7 @@ struct us_socket_t *on_echo_socket_open(struct us_socket_t *s, int is_client, ch
 	es->backpressure = 0;
 	es->length = 0;
 
-	/* Start a timeout to close the socekt if boring */
+	/* Start a timeout to close the socket if boring */
 	us_socket_timeout(SSL, s, 30);
 
 	printf("Client connected\n");

--- a/examples/hammer_test.c
+++ b/examples/hammer_test.c
@@ -436,7 +436,7 @@ int main() {
     us_socket_timeout(SSL, (struct us_socket_t *) listen_socket, 16);
 
     if (listen_socket) {
-        printf("Running hammer test\n");
+        printf("Running hammer test over tcpip\n");
         print_progress(0);
         next_connection();
 

--- a/examples/hammer_test_unix.c
+++ b/examples/hammer_test_unix.c
@@ -1,0 +1,462 @@
+/* This example, or test, is a moron test where the library is being hammered in all the possible ways randomly over time */
+
+#include <libusockets.h>
+const int SSL = 1;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define PBSTR "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
+#define PBWIDTH 60
+
+void print_progress(double percentage) {
+    static int last_val = -1;
+    int val = (int) (percentage * 100);
+    if (last_val != -1 && val == last_val) {
+        return;
+    }
+    last_val = val;
+    int lpad = (int) (percentage * PBWIDTH);
+    int rpad = PBWIDTH - lpad;
+    printf("\r%3d%% [%.*s%*s]", val, lpad, PBSTR, rpad, "");
+    fflush(stdout);
+}
+
+// todo: properly put all of these in various ext data so to test them!
+int opened_connections, closed_connections, operations_done;
+struct us_socket_context_t *http_context, *websocket_context;
+struct us_listen_socket_t *listen_socket;
+
+int opened_clients, opened_servers, closed_clients, closed_servers;
+
+// put in loop ext data
+void *long_buffer;
+unsigned int long_length = 5 * 1024 * 1024;
+
+// also make sure to have socket ext data
+// and context ext data
+// and loop ext data
+
+const double pad_should_always_be = 14.652752;
+
+/* We begin smaller than the WS so that resize must fail (opposite of what we have in uWS).
+ * This triggers the libuv resize crash that must be fixed. */
+struct http_socket {
+    double pad_invariant;
+    int is_http;
+    double post_pad_invariant;
+    int is_client;
+    char content[128];
+};
+
+struct web_socket {
+    double pad_invariant;
+    int is_http;
+    double post_pad_invariant;
+    int is_client;
+    char content[1024];
+};
+
+/* This checks the ext data state according to callbacks */
+void assume_state(struct us_socket_t *s, int is_http) {
+    struct http_socket *hs = (struct http_socket *) us_socket_ext(SSL, s);
+
+    if (hs->pad_invariant != pad_should_always_be || hs->post_pad_invariant != pad_should_always_be) {
+        printf("ERROR: Pad invariant is not correct!\n");
+        free((void *) 1);
+    }
+
+    if (hs->is_http != is_http) {
+        printf("ERROR: State is: %d should be: %d. Terminating now!\n", hs->is_http, is_http);
+        free((void *) 1);
+    }
+
+    // try and cause havoc (different size)
+    if (hs->is_http) {
+        memset(hs->content, 0, 128);
+    } else {
+        memset(hs->content, 0, 1024);
+    }
+}
+
+struct http_context {
+    // link to the other context here
+    char content[1];
+};
+
+// todo: it would be nice to randomly select socket instead of
+// using the one responsible for the event
+struct us_socket_t *perform_random_operation(struct us_socket_t *s) {
+    switch (rand() % 5) {
+        case 0: {
+            // close
+            return us_socket_close(SSL, s, 0, NULL);
+        }
+        case 1: {
+            // adoption cannot happen if closed!
+            if (!us_socket_is_closed(SSL, s)) {
+                if (rand() % 2) {
+                    s = us_socket_context_adopt_socket(SSL, websocket_context, s, sizeof(struct web_socket));
+                    struct http_socket *hs = (struct http_socket *) us_socket_ext(SSL, s);
+                    hs->is_http = 0;
+                } else {
+                    s = us_socket_context_adopt_socket(SSL, http_context, s, sizeof(struct http_socket));
+                    struct http_socket *hs = (struct http_socket *) us_socket_ext(SSL, s);
+                    hs->is_http = 1;
+                }
+            }
+
+            return perform_random_operation(s);
+        }
+        case 2: {
+            // write - causes the other end to receive the data (event) and possibly us
+            // to receive on writable event - could it be that we get stuck if the other end is closed?
+            // no because, if we do not get ack in time we will timeout after some time
+            us_socket_write(SSL, s, (char *) long_buffer, rand() % long_length, 0);
+        }
+        break;
+        case 3: {
+            // shutdown (on macOS we can get stuck in fin_wait_2 for some weird reason!)
+            // if we send fin, the other end sends data but then on writable closes? then fin is not sent?
+            // so we need to timeout here to ensure we are closed if no fin is received within 30 seconds
+            us_socket_shutdown(SSL, s);
+            us_socket_timeout(SSL, s, 16);
+        }
+        break;
+        case 4: {
+            /* Triggers all timeouts next iteration */
+            us_socket_timeout(SSL, s, 4);
+            us_wakeup_loop(us_socket_context_loop(SSL, us_socket_context(SSL, s)));
+        }
+        break;
+    }
+    return s;
+}
+
+void on_wakeup(struct us_loop_t *loop) {
+    // note: we expose internal functions to trigger a timeout sweep to find bugs
+    extern void us_internal_timer_sweep(struct us_loop_t *loop);
+    
+    //us_internal_timer_sweep(loop);
+}
+
+// maybe use thse to count spurious wakeups?
+// that is, if we get tons of pre/post over and over without any events
+// that would point towards 100% cpu usage kind of bugs
+void on_pre(struct us_loop_t *loop) {
+
+}
+
+void on_post(struct us_loop_t *loop) {
+    // check if we did perform_random_operation
+}
+
+struct us_socket_t *on_web_socket_writable(struct us_socket_t *s) {
+    assume_state(s, 0);
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_http_socket_writable(struct us_socket_t *s) {
+    assume_state(s, 1);
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_web_socket_close(struct us_socket_t *s, int code, void *reason) {
+    assume_state(s, 0);
+
+    struct web_socket *ws = (struct web_socket *) us_socket_ext(SSL, s);
+
+    if (ws->is_client) {
+        closed_clients++;
+    } else {
+        closed_servers++;
+    }
+
+    closed_connections++;
+
+    print_progress((double) closed_connections / 10000);
+
+    if (closed_connections == 10000) {
+        if (opened_clients != 5000) {
+            printf("VA I HELVETE STÄNGER LISTEN INNAN ÖPPNAT ALLA CLIENTS! %d\n", opened_clients);
+            exit(1);
+        }
+
+        us_listen_socket_close(SSL, listen_socket);
+    } else {
+        return perform_random_operation(s);
+    }
+    return s;
+}
+
+struct us_socket_t *on_http_socket_close(struct us_socket_t *s, int code, void *reason) {
+    assume_state(s, 1);
+
+    struct http_socket *hs = (struct http_socket *) us_socket_ext(SSL, s);
+
+    if (hs->is_client) {
+        closed_clients++;
+    } else {
+        closed_servers++;
+    }
+
+    print_progress((double) closed_connections / 10000);
+
+    closed_connections++;
+    
+    if (closed_connections == 10000) {
+        if (opened_clients != 5000) {
+            printf("VA I HELVETE STÄNGER LISTEN INNAN ÖPPNAT ALLA CLIENTS! %d\n", opened_clients);
+            exit(1);
+        }
+        us_listen_socket_close(SSL, listen_socket);
+    } else {
+        return perform_random_operation(s);
+    }
+    return s;
+}
+
+/* Same as below */
+struct us_socket_t *on_web_socket_end(struct us_socket_t *s) {
+    assume_state(s, 0);
+
+    // we need to close on shutdown
+    s = us_socket_close(SSL, s, 0, NULL);
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_http_socket_end(struct us_socket_t *s) {
+    assume_state(s, 1);
+
+    /* Getting a FIN and we just close down */
+    s = us_socket_close(SSL, s, 0, NULL);
+
+    /* I guess we do this, to extra check that following actions are ignored,
+     * we really should just return s here, but to stress the lib we do this */
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_web_socket_data(struct us_socket_t *s, char *data, int length) {
+    assume_state(s, 0);
+
+    if (length == 0) {
+        printf("ERROR: Got data event with no data\n");
+        exit(-1);
+    }
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_http_socket_data(struct us_socket_t *s, char *data, int length) {
+    assume_state(s, 1);
+
+    if (length == 0) {
+        printf("ERROR: Got data event with no data\n");
+        exit(-1);
+    }
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_web_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {
+    // fail here, this can never happen!
+    printf("ERROR: on_web_socket_open called!\n");
+    exit(-2);
+}
+
+/* This one drives progress, or well close actually drives progress but this allows sockets to close */
+struct us_socket_t *next_connection() {
+
+    if (opened_clients == 5000) {
+        printf("ERROR! next_connection called when already having made all!\n");
+        free((void *) -1);
+    }
+
+    struct us_socket_t *connection_socket;
+    if (!(connection_socket = us_socket_context_connect_unix(SSL, http_context, "hammer_test.sock", 0, sizeof(struct http_socket)))) {
+        /* This one we do not deal with, so just exit */
+        printf("FAILED TO START CONNECTION, WILL EXIT NOW\n");
+        exit(1);
+    }
+
+    /* Typically, in real applications you would want to us_socket_timeout the connection_socket
+     * to track a maximal connection timeout. However, because this test relies on perfect sync
+     * between number of server side sockets and number of client side sockets, we cannot use this
+     * feature since it is possible we send a SYN, timeout and close the client socket while
+     * the listen side accepts the SYN and opens up while the client side is missing, causing the
+     * test to fail. */
+
+    return connection_socket;
+}
+
+struct us_socket_t *on_http_socket_connect_error(struct us_socket_t *s, int code) {
+    /* On macOS it is common for a connect to end up here. Even though we have no real timeout
+     * it seems the system has a default connect timeout and we end up here. */
+    next_connection();
+
+    return s;
+}
+
+struct us_socket_t *on_web_socket_connect_error(struct us_socket_t *s, int code) {
+    printf("ERROR: WebSocket can never get connect errors!\n");
+    exit(1);
+
+    return s;
+}
+
+struct us_socket_t *on_http_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {
+    struct http_socket *hs = (struct http_socket *) us_socket_ext(SSL, s);
+    hs->is_http = 1;
+    hs->pad_invariant = pad_should_always_be;
+    hs->post_pad_invariant = pad_should_always_be;
+    hs->is_client = is_client;
+
+    assume_state(s, 1);
+
+    opened_connections++;
+    if (is_client) {
+        opened_clients++;
+    } else {
+        opened_servers++;
+    }
+
+    if (is_client && opened_clients < 5000) {
+        next_connection();
+    }
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_web_socket_timeout(struct us_socket_t *s) {
+    assume_state(s, 0);
+
+    return perform_random_operation(s);
+}
+
+struct us_socket_t *on_http_socket_timeout(struct us_socket_t *s) {
+
+    /* If we timed out before being established, we should always cancel connecting and connect again */
+    if (!us_socket_is_established(SSL, s)) {
+
+        if (s != (struct us_socket_t *) listen_socket) {
+            /* Connect sockets are not allowed to timeout since, in this hammer_test
+             * we can get a connection server-side yet no connection client side due
+             * to sending a SYN, the closing due to timeout, yet having the server side
+             * eventually accept and open its side causing out of sync */
+            printf("CONNECTION TIMEOUT!!! CANNOT HAPPEN!!\n");
+            exit(1);
+
+            /* It would be perfectly valid to perform the following if we did not care for
+             * having number of opened sockets server side synced with number of opened sockets
+             * client side (the following is typically what you would do) */
+            us_socket_close_connecting(SSL, s);
+            next_connection();
+        }
+
+        /* Okay, so this is the listen_socket */
+        static time_t last_time;
+
+        if (last_time && time(0) - last_time == 0) {
+            printf("TIMER IS FIRING TOO FAST!!!\n");
+            exit(1);
+        }
+
+        last_time = time(0);
+
+        print_progress((double) closed_connections / 10000);
+        us_socket_timeout(SSL, s, 16);
+        return s;
+    }
+
+    /* Assume this established socket is in the state of http */
+    assume_state(s, 1);
+
+    /* An established socket has timed out */
+    if (us_socket_is_shut_down(SSL, s)) {
+        /* If we have sent FIN but not received a FIN on the other side,
+         * we can actually end up stuck in FIN_WAIT_2 without seeing any
+         * progress (FIN_WAIT_2 is not a state kqueue will report as we
+         * still can get data). macOS does not seem to send FIN for closed
+         * sockets in all cases. */
+        return us_socket_close(SSL, s, 0, 0);
+    }
+
+    return perform_random_operation(s);
+}
+
+int main() {
+    srand(time(0));
+    long_buffer = calloc(long_length, 1);
+
+    struct us_loop_t *loop = us_create_loop(0, on_wakeup, on_pre, on_post, 0);
+
+    // us_loop_on_wakeup()
+    // us_loop_on_pre()
+    // us_loop_on_post()
+    // us_loop_on_poll()
+    // us_loop_on_timer()
+
+
+    // these are ignored for non-SSL
+    struct us_socket_context_options_t options = {};
+    options.key_file_name = "/home/alexhultman/uWebSockets.js/misc/key.pem";
+    options.cert_file_name = "/home/alexhultman/uWebSockets.js/misc/cert.pem";
+    options.passphrase = "1234";
+
+    http_context = us_create_socket_context(SSL, loop, sizeof(struct http_context), options);
+
+
+    us_socket_context_on_open(SSL, http_context, on_http_socket_open);
+    us_socket_context_on_data(SSL, http_context, on_http_socket_data);
+    us_socket_context_on_writable(SSL, http_context, on_http_socket_writable);
+    us_socket_context_on_close(SSL, http_context, on_http_socket_close);
+    us_socket_context_on_timeout(SSL, http_context, on_http_socket_timeout);
+    us_socket_context_on_end(SSL, http_context, on_http_socket_end);
+    us_socket_context_on_connect_error(SSL, http_context, on_http_socket_connect_error);
+
+    websocket_context = us_create_child_socket_context(SSL, http_context, sizeof(struct http_context));
+
+    us_socket_context_on_open(SSL, websocket_context, on_web_socket_open);
+    us_socket_context_on_data(SSL, websocket_context, on_web_socket_data);
+    us_socket_context_on_writable(SSL, websocket_context, on_web_socket_writable);
+    us_socket_context_on_close(SSL, websocket_context, on_web_socket_close);
+    us_socket_context_on_timeout(SSL, websocket_context, on_web_socket_timeout);
+    us_socket_context_on_end(SSL, websocket_context, on_web_socket_end);
+    us_socket_context_on_connect_error(SSL, websocket_context, on_web_socket_connect_error);
+
+    listen_socket = us_socket_context_listen_unix(SSL, http_context, "hammer_test.sock", 0, sizeof(struct http_socket));
+
+    /* We use the listen socket as a way to check so that timeout stamps don't
+     * deviate from wallclock time - let's use 16 seconds and check that we have
+     * at least 1 second diff since last trigger (allows iteration lag of 15 seconds) */
+    us_socket_timeout(SSL, (struct us_socket_t *) listen_socket, 16);
+
+    if (listen_socket) {
+        printf("Running hammer test over unix domain socket\n");
+        print_progress(0);
+        next_connection();
+
+        us_loop_run(loop);
+    } else {
+        printf("Cannot listen to hammer_test.sock!\n");
+    }
+
+    us_socket_context_free(SSL, websocket_context);
+    us_socket_context_free(SSL, http_context);
+    us_loop_free(loop);
+    free(long_buffer);
+    print_progress(1);
+    printf("\n");
+
+    if (opened_clients == 5000 && closed_clients == 5000 && opened_servers == 5000 && closed_servers == 5000) {
+        printf("ALL GOOD\n");
+        return 0;
+    } else {
+        printf("MISMATCHING! FAILED!\n");
+        return 1;
+    }
+}

--- a/src/context.c
+++ b/src/context.c
@@ -203,6 +203,36 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
     return ls;
 }
 
+struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context, const char *path, int options, int socket_ext_size) {
+#ifndef LIBUS_NO_SSL
+    if (ssl) {
+        return us_internal_ssl_socket_context_listen_unix((struct us_internal_ssl_socket_context_t *) context, path, options, socket_ext_size);
+    }
+#endif
+
+    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd = bsd_create_listen_socket_unix(path, options);
+
+    if (listen_socket_fd == LIBUS_SOCKET_ERROR) {
+        return 0;
+    }
+
+    struct us_poll_t *p = us_create_poll(context->loop, 0, sizeof(struct us_listen_socket_t));
+    us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
+    us_poll_start(p, context->loop, LIBUS_SOCKET_READABLE);
+
+    struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
+
+    ls->s.context = context;
+    ls->s.timeout = 0;
+    ls->s.low_prio_state = 0;
+    ls->s.next = 0;
+    us_internal_socket_context_link(context, &ls->s);
+
+    ls->socket_ext_size = socket_ext_size;
+
+    return ls;
+}
+
 struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
 #ifndef LIBUS_NO_SSL
     if (ssl) {
@@ -211,6 +241,34 @@ struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_
 #endif
 
     LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(host, port, source_host, options);
+    if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
+        return 0;
+    }
+
+    /* Connect sockets are semi-sockets just like listen sockets */
+    struct us_poll_t *p = us_create_poll(context->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
+    us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
+    us_poll_start(p, context->loop, LIBUS_SOCKET_WRITABLE);
+
+    struct us_socket_t *connect_socket = (struct us_socket_t *) p;
+
+    /* Link it into context so that timeout fires properly */
+    connect_socket->context = context;
+    connect_socket->timeout = 0;
+    connect_socket->low_prio_state = 0;
+    us_internal_socket_context_link(context, connect_socket);
+
+    return connect_socket;
+}
+
+struct us_socket_t *us_socket_context_connect_unix(int ssl, struct us_socket_context_t *context, const char *server_path, int options, int socket_ext_size) {
+#ifndef LIBUS_NO_SSL
+    if (ssl) {
+        return (struct us_socket_t *) us_internal_ssl_socket_context_connect_unix((struct us_internal_ssl_socket_context_t *) context, server_path, options, socket_ext_size);
+    }
+#endif
+
+    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket_unix(server_path, options);
     if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -664,8 +664,16 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
     return us_socket_context_listen(0, &context->sc, host, port, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
+struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_internal_ssl_socket_context_t *context, const char *path, int options, int socket_ext_size) {
+    return us_socket_context_listen_unix(0, &context->sc, path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+}
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
     return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, source_host, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+}
+
+struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(struct us_internal_ssl_socket_context_t *context, const char *server_path, int options, int socket_ext_size) {
+    return (struct us_internal_ssl_socket_t *) us_socket_context_connect_unix(0, &context->sc, server_path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
 void us_internal_ssl_socket_context_on_open(struct us_internal_ssl_socket_context_t *context, struct us_internal_ssl_socket_t *(*on_open)(struct us_internal_ssl_socket_t *s, int is_client, char *ip, int ip_length)) {

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -169,8 +169,15 @@ void us_internal_ssl_socket_context_on_connect_error(struct us_internal_ssl_sock
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, int options, int socket_ext_size);
 
+struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_internal_ssl_socket_context_t *context,
+    const char *path, int options, int socket_ext_size);
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);
+
+    
+struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect_unix(struct us_internal_ssl_socket_context_t *context,
+    const char *server_path, int options, int socket_ext_size);
 
 int us_internal_ssl_socket_write(struct us_internal_ssl_socket_t *s, const char *data, int length, int msg_more);
 void us_internal_ssl_socket_timeout(struct us_internal_ssl_socket_t *s, unsigned int seconds);

--- a/src/internal/networking/bsd.h
+++ b/src/internal/networking/bsd.h
@@ -96,9 +96,13 @@ int bsd_would_block();
 // listen both on ipv6 and ipv4
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options);
 
+LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, int options);
+
 /* Creates an UDP socket bound to the hostname and port */
 LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port);
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(const char *host, int port, const char *source_host, int options);
+
+LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, int options);
 
 #endif // BSD_H

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -176,12 +176,18 @@ WIN32_EXPORT void *us_socket_context_ext(int ssl, struct us_socket_context_t *co
 WIN32_EXPORT struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_context_t *context,
     const char *host, int port, int options, int socket_ext_size);
 
+WIN32_EXPORT struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context,
+    const char *path, int options, int socket_ext_size);
+
 /* listen_socket.c/.h */
 WIN32_EXPORT void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);
 
 /* Land in on_open or on_connection_error or return null or return socket */
 WIN32_EXPORT struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);
+
+WIN32_EXPORT struct us_socket_t *us_socket_context_connect_unix(int ssl, struct us_socket_context_t *context,
+    const char *server_path, int options, int socket_ext_size);
 
 /* Is this socket established? Can be used to check if a connecting socket has fired the on_open event yet.
  * Can also be used to determine if a socket is a listen_socket or not, but you probably know that already. */


### PR DESCRIPTION
First step to add unix domain socket support for uWebSockets.
According to our [previous discussion](https://github.com/uNetworking/uWebSockets/discussions/1438#discussioncomment-2570789), this PR  add unix sockets supports both server(listen) and client(connect) side, it also compiles successfully on Windows. Please let me know if there are somethings wrong you think, I am willing to make it better.
@alexhultman 