### PR TITLE
fix custom ssl ciphers support

### DIFF
--- a/misc/manual.md
+++ b/misc/manual.md
@@ -41,6 +41,8 @@ struct us_socket_context_options_t {
     const char *cert_file_name;
     const char *passphrase;
     const char *dh_params_file_name;
+    const char *ca_file_name;
+    const char *ssl_ciphers;
     int ssl_prefer_low_memory_usage;
 };
 

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -516,12 +516,12 @@ SSL_CTX *create_ssl_context_from_options(struct us_socket_context_options_t opti
         }
     }
 
-    // if (options.ssl_ciphers) {
-    //     if (SSL_CTX_set_cipher_list(ssl_context, options.ssl_ciphers) != 1) {
-    //         free_ssl_context(ssl_context);
-    //         return NULL;
-    //     }
-    // }
+    if (options.ssl_ciphers) {
+        if (SSL_CTX_set_cipher_list(ssl_context, options.ssl_ciphers) != 1) {
+            free_ssl_context(ssl_context);
+            return NULL;
+        }
+    }
 
     /* This must be free'd with free_ssl_context, not SSL_CTX_free */
     return ssl_context;

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -129,6 +129,7 @@ struct us_socket_context_options_t {
     const char *passphrase;
     const char *dh_params_file_name;
     const char *ca_file_name;
+    const char *ssl_ciphers;
     int ssl_prefer_low_memory_usage; /* Todo: rename to prefer_low_memory_usage and apply for TCP as well */
 };
 


### PR DESCRIPTION
Fixes #173 
My last PR broke the build due to missing member in the struct. Sorry about that.
This PR fixes it and re-adds the custom ciphers support