### PR TITLE
declare 'take_all()' before it's used

### DIFF
--- a/src/quic.c
+++ b/src/quic.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+void leave_all();
+
 /*
 struct sockaddr_in client_addr = {
     AF_INET,


### PR DESCRIPTION
alternatively, it may make sense to declare this in the header. it's unclear if it really belongs there; possibly it should stay in quic.c and become static too.

```
third_party/usockets/libusockets/src/quic.c:370:9: error: call to undeclared function 'leave_all'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        leave_all();//free(header_set);
        ^
```
```
third_party/usockets/libusockets/src/quic.c:604:6: error: conflicting types for 'leave_all'
void leave_all() {
     ^
third_party/usockets/libusockets/src/quic.c:370:9: note: previous implicit declaration is here
        leave_all();//free(header_set);
        ^
```