### PR TITLE
clean up ext_size in quic api

### DIFF
--- a/examples/http3_client.c
+++ b/examples/http3_client.c
@@ -171,7 +171,7 @@ int main() {
     };
 
     /* Create quic socket context (assumes h3 for now) */
-    context = us_create_quic_socket_context(loop, options);
+    context = us_create_quic_socket_context(loop, options, 0);
 
     /* Specify application callbacks */
     us_quic_socket_context_on_stream_data(context, on_stream_data);

--- a/examples/http3_server.c
+++ b/examples/http3_server.c
@@ -89,7 +89,7 @@ int main() {
     };
 
     /* Create quic socket context (assumes h3 for now) */
-    context = us_create_quic_socket_context(loop, options);
+    context = us_create_quic_socket_context(loop, options, 0);
 
     /* Specify application callbacks */
     us_quic_socket_context_on_stream_data(context, on_stream_data);

--- a/src/quic.c
+++ b/src/quic.c
@@ -334,7 +334,7 @@ lsquic_conn_ctx_t *on_new_conn(void *stream_if_ctx, lsquic_conn_t *c) {
     return context;
 }
 
-void us_quic_socket_create_stream(us_quic_socket_t *s, unsigned int ext_size) {
+void us_quic_socket_create_stream(us_quic_socket_t *s) {
     lsquic_conn_make_stream((lsquic_conn_t *) s);
 }
 
@@ -908,14 +908,14 @@ us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, 
     return context;
 }
 
-us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size) {
+us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port) {
     /* We literally do create a listen socket */
     /*context->udp_socket = */us_create_udp_socket(context->loop, /*context->recv_buf*/ NULL, on_udp_socket_data, on_udp_socket_writable, host, port, context);
     return NULL;//context->udp_socket;
 }
 
 /* A client connection is its own UDP socket, while a server connection makes use of the shared listen UDP socket */
-us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size) {
+us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port) {
     printf("Connecting..\n");
 
 

--- a/src/quic.c
+++ b/src/quic.c
@@ -334,7 +334,7 @@ lsquic_conn_ctx_t *on_new_conn(void *stream_if_ctx, lsquic_conn_t *c) {
     return context;
 }
 
-void us_quic_socket_create_stream(us_quic_socket_t *s, int ext_size) {
+void us_quic_socket_create_stream(us_quic_socket_t *s, unsigned int ext_size) {
     lsquic_conn_make_stream((lsquic_conn_t *) s);
 }
 
@@ -800,7 +800,7 @@ void *us_quic_socket_context_ext(us_quic_socket_context_t *context) {
 }
 
 // this will be for both client and server, but will be only for either h3 or raw quic
-us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, us_quic_socket_context_options_t options, int ext_size) {
+us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, us_quic_socket_context_options_t options, unsigned int ext_size) {
 
 
     // every _listen_ call creates a new udp socket that feeds inputs to the engine in the context
@@ -908,14 +908,14 @@ us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, 
     return context;
 }
 
-us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, int ext_size) {
+us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size) {
     /* We literally do create a listen socket */
     /*context->udp_socket = */us_create_udp_socket(context->loop, /*context->recv_buf*/ NULL, on_udp_socket_data, on_udp_socket_writable, host, port, context);
     return NULL;//context->udp_socket;
 }
 
 /* A client connection is its own UDP socket, while a server connection makes use of the shared listen UDP socket */
-us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, int ext_size) {
+us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size) {
     printf("Connecting..\n");
 
 

--- a/src/quic.h
+++ b/src/quic.h
@@ -37,10 +37,10 @@ void us_quic_socket_context_set_header(us_quic_socket_context_t *context, int in
 void us_quic_socket_context_send_headers(us_quic_socket_context_t *context, us_quic_stream_t *s, int num, int has_body);
 
 us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, us_quic_socket_context_options_t options, unsigned int ext_size);
-us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size);
-us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size);
+us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port);
+us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port);
 
-void us_quic_socket_create_stream(us_quic_socket_t *s, unsigned int ext_size);
+void us_quic_socket_create_stream(us_quic_socket_t *s);
 us_quic_socket_t *us_quic_stream_socket(us_quic_stream_t *s);
 
 /* This one is ugly and is only used to make clean examples */

--- a/src/quic.h
+++ b/src/quic.h
@@ -36,11 +36,11 @@ int us_quic_socket_context_get_header(us_quic_socket_context_t *context, int ind
 void us_quic_socket_context_set_header(us_quic_socket_context_t *context, int index, char *key, int key_length, char *value, int value_length);
 void us_quic_socket_context_send_headers(us_quic_socket_context_t *context, us_quic_stream_t *s, int num, int has_body);
 
-us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, us_quic_socket_context_options_t options, int ext_size);
-us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, int ext_size);
-us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, int ext_size);
+us_quic_socket_context_t *us_create_quic_socket_context(struct us_loop_t *loop, us_quic_socket_context_options_t options, unsigned int ext_size);
+us_quic_listen_socket_t *us_quic_socket_context_listen(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size);
+us_quic_socket_t *us_quic_socket_context_connect(us_quic_socket_context_t *context, char *host, int port, unsigned int ext_size);
 
-void us_quic_socket_create_stream(us_quic_socket_t *s, int ext_size);
+void us_quic_socket_create_stream(us_quic_socket_t *s, unsigned int ext_size);
 us_quic_socket_t *us_quic_stream_socket(us_quic_stream_t *s);
 
 /* This one is ugly and is only used to make clean examples */


### PR DESCRIPTION
I'm not sure if these arguments are implicitly zero when omitted for others, but without providing or deleting the parameters the examples fail to build with my toolchain.