### PR TITLE
Add support for already-listening sockets

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -258,22 +258,7 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
         return 0;
     }
 
-    struct us_poll_t *p = us_create_poll(context->loop, 0, sizeof(struct us_listen_socket_t));
-    us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
-    us_poll_start(p, context->loop, LIBUS_SOCKET_READABLE);
-
-    struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
-
-    ls->s.context = context;
-    ls->s.timeout = 255;
-    ls->s.long_timeout = 255;
-    ls->s.low_prio_state = 0;
-    ls->s.next = 0;
-    us_internal_socket_context_link_listen_socket(context, ls);
-
-    ls->socket_ext_size = socket_ext_size;
-
-    return ls;
+    return us_socket_context_listen_direct(ssl, context, listen_socket_fd, options, socket_ext_size); 
 }
 
 struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context, const char *path, int options, int socket_ext_size) {
@@ -289,6 +274,16 @@ struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_sock
         return 0;
     }
 
+    return us_socket_context_listen_direct(ssl, context, listen_socket_fd, options, socket_ext_size); 
+}
+
+struct us_listen_socket_t *us_socket_context_listen_direct(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR listen_socket_fd, int options, int socket_ext_size) {
+#ifndef LIBUS_NO_SSL
+    if (ssl) {
+        return us_internal_ssl_socket_context_listen_direct((struct us_internal_ssl_socket_context_t *) context, listen_socket_fd, options, socket_ext_size);
+    }
+#endif
+    
     struct us_poll_t *p = us_create_poll(context->loop, 0, sizeof(struct us_listen_socket_t));
     us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
     us_poll_start(p, context->loop, LIBUS_SOCKET_READABLE);
@@ -306,6 +301,7 @@ struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_sock
 
     return ls;
 }
+
 
 struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
 #ifndef LIBUS_NO_SSL

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -693,6 +693,10 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_
     return us_socket_context_listen_unix(0, &context->sc, path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
+struct us_listen_socket_t *us_internal_ssl_socket_context_listen_direct(struct us_internal_ssl_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR listen_socket_fd, int options, int socket_ext_size) {
+    return us_socket_context_listen_direct(0, &context->sc, listen_socket_fd, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
+}
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
     return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, source_host, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -186,6 +186,9 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_internal_ssl_socket_context_t *context,
     const char *path, int options, int socket_ext_size);
 
+struct us_listen_socket_t *us_internal_ssl_socket_context_listen_direct(struct us_internal_ssl_socket_context_t *context,
+    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd, int options, int socket_ext_size);
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);
 

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -184,6 +184,9 @@ struct us_listen_socket_t *us_socket_context_listen(int ssl, struct us_socket_co
 struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_socket_context_t *context,
     const char *path, int options, int socket_ext_size);
 
+struct us_listen_socket_t *us_socket_context_listen_direct(int ssl, struct us_socket_context_t *context,
+    LIBUS_SOCKET_DESCRIPTOR listen_socket_fd, int options, int socket_ext_size);
+
 /* listen_socket.c/.h */
 void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);
 


### PR DESCRIPTION
**Background**. It's often desirable to work off a given listening fd, rather than opening a port or UNIX domain socket. For example, a listening FD can be passed from a process in a global network namespace to a server in a restricted namespace, for security/isolation. In systemd socket activation, the externally-facing network or domain socket is bound and listened by systemd. When a new connection arrives, the service is started with the socket descriptor passed as an int in the LISTEN_FDS environment variable. 

**Implementation**. `us_socket_context_listen_direct` hastily added without tests or examples. Should probably be renamed, since it takes a listening socket, but doesn't call listen() itself. Just want to get this ball rolling, in the hopes that this mode is eventually supported by Bun. With node, it's possible to run servers directly in this manner. cc @Jarred-Sumner