### PR TITLE
Feature / Adopt externally accepted sockets into libusockets

### DIFF
--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -694,6 +694,11 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_
     return us_socket_context_listen_unix(0, &context->sc, path, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }
 
+struct us_internal_ssl_socket_t *us_internal_ssl_adopt_accepted_socket(struct us_internal_ssl_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR accepted_fd,
+    unsigned int socket_ext_size, char *addr_ip, int addr_ip_length) {
+    return (struct us_internal_ssl_socket_t *) us_adopt_accepted_socket(0, &context->sc, accepted_fd, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size, addr_ip, addr_ip_length);
+}
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context, const char *host, int port, const char *source_host, int options, int socket_ext_size) {
     return (struct us_internal_ssl_socket_t *) us_socket_context_connect(0, &context->sc, host, port, source_host, options, sizeof(struct us_internal_ssl_socket_t) - sizeof(struct us_socket_t) + socket_ext_size);
 }

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -194,6 +194,9 @@ struct us_listen_socket_t *us_internal_ssl_socket_context_listen(struct us_inter
 struct us_listen_socket_t *us_internal_ssl_socket_context_listen_unix(struct us_internal_ssl_socket_context_t *context,
     const char *path, int options, int socket_ext_size);
 
+struct us_internal_ssl_socket_t *us_internal_ssl_adopt_accepted_socket(struct us_internal_ssl_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR accepted_fd,
+    unsigned int socket_ext_size, char *addr_ip, int addr_ip_length);
+
 struct us_internal_ssl_socket_t *us_internal_ssl_socket_context_connect(struct us_internal_ssl_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);
 

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -190,6 +190,10 @@ struct us_listen_socket_t *us_socket_context_listen_unix(int ssl, struct us_sock
 /* listen_socket.c/.h */
 void us_listen_socket_close(int ssl, struct us_listen_socket_t *ls);
 
+/* Adopt a socket which was accepted either internally, or from another accept() outside libusockets */
+struct us_socket_t *us_adopt_accepted_socket(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR client_fd,
+    unsigned int socket_ext_size, char *addr_ip, int addr_ip_length);
+
 /* Land in on_open or on_connection_error or return null or return socket */
 struct us_socket_t *us_socket_context_connect(int ssl, struct us_socket_context_t *context,
     const char *host, int port, const char *source_host, int options, int socket_ext_size);

--- a/src/loop.c
+++ b/src/loop.c
@@ -194,6 +194,32 @@ void us_internal_loop_post(struct us_loop_t *loop) {
     loop->data.post_cb(loop);
 }
 
+struct us_socket_t *us_adopt_accepted_socket(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR accepted_fd,
+    unsigned int socket_ext_size, char *addr_ip, int addr_ip_length) {
+    if (ssl) {
+        return (struct us_socket *)us_internal_ssl_adopt_accepted_socket((struct us_internal_ssl_socket_context_t *)context, accepted_fd,
+            socket_ext_size, addr_ip, addr_ip_length);
+    }
+    struct us_poll_t *accepted_p = us_create_poll(context->loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + socket_ext_size);
+    us_poll_init(accepted_p, accepted_fd, POLL_TYPE_SOCKET);
+    us_poll_start(accepted_p, context->loop, LIBUS_SOCKET_READABLE);
+
+    struct us_socket_t *s = (struct us_socket_t *) accepted_p;
+
+    s->context = context;
+    s->timeout = 255;
+    s->long_timeout = 255;
+    s->low_prio_state = 0;
+
+    /* We always use nodelay */
+    bsd_socket_nodelay(accepted_fd, 1);
+
+    us_internal_socket_context_link_socket(context, s);
+
+    context->on_open(s, 0, addr_ip, addr_ip_length);
+    return s;
+}
+
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events) {
     switch (us_internal_poll_type(p)) {
     case POLL_TYPE_CALLBACK: {
@@ -247,23 +273,9 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                     /* Todo: stop timer if any */
 
                     do {
-                        struct us_poll_t *accepted_p = us_create_poll(us_socket_context(0, &listen_socket->s)->loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + listen_socket->socket_ext_size);
-                        us_poll_init(accepted_p, client_fd, POLL_TYPE_SOCKET);
-                        us_poll_start(accepted_p, listen_socket->s.context->loop, LIBUS_SOCKET_READABLE);
-
-                        struct us_socket_t *s = (struct us_socket_t *) accepted_p;
-
-                        s->context = listen_socket->s.context;
-                        s->timeout = 255;
-                        s->long_timeout = 255;
-                        s->low_prio_state = 0;
-
-                        /* We always use nodelay */
-                        bsd_socket_nodelay(client_fd, 1);
-
-                        us_internal_socket_context_link_socket(listen_socket->s.context, s);
-
-                        listen_socket->s.context->on_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
+                        /* adopt the newly accepted socket */
+                        us_adopt_accepted_socket(0, us_socket_context(0, &listen_socket->s),
+                            client_fd, listen_socket->socket_ext_size, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
 
                         /* Exit accept loop if listen socket was closed in on_open handler */
                         if (us_socket_is_closed(0, &listen_socket->s)) {

--- a/src/loop.c
+++ b/src/loop.c
@@ -197,7 +197,7 @@ void us_internal_loop_post(struct us_loop_t *loop) {
 struct us_socket_t *us_adopt_accepted_socket(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR accepted_fd,
     unsigned int socket_ext_size, char *addr_ip, int addr_ip_length) {
     if (ssl) {
-        return (struct us_socket *)us_internal_ssl_adopt_accepted_socket((struct us_internal_ssl_socket_context_t *)context, accepted_fd,
+        return (struct us_socket_t *)us_internal_ssl_adopt_accepted_socket((struct us_internal_ssl_socket_context_t *)context, accepted_fd,
             socket_ext_size, addr_ip, addr_ip_length);
     }
     struct us_poll_t *accepted_p = us_create_poll(context->loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + socket_ext_size);


### PR DESCRIPTION
# Description

This allows for sockets that were obtained from an external `accept(2)` to be adopted into uSockets. 

Such sockets may come from another library, another external event-loop, or from a forked-server pattern, like [inetd](https://en.wikipedia.org/wiki/Inetd), [systemd-socket-activate](https://www.freedesktop.org/software/systemd/man/latest/systemd-socket-activate.html) etc.

This PR is the basis for https://github.com/uNetworking/uWebSockets/pull/1697 on uWebSockets. 

# Justification

A forked process serving a single websocket session can increase safety, as each user is isolated in a separate process. In addition it can do impersonation via [setuid(2)](https://www.man7.org/linux/man-pages/man2/setuid.2.html) to restrict access on the host to that of an authenticated user. The design can also interface legacy "single-user" back-end software. It can increase robustness, limiting the effects of crashes to one session.

This is similar to what libwebsockets does in its "socket adoption helpers":

https://libwebsockets.org/lws-api-doc-main/html/group__sock-adopt.html

# Implementation

It basically refactors the existing accepted socket adoption from `us_internal_dispatch_ready_poll()` into a separate function `us_adopt_accepted_socket()`, and makes it available publicly.

Some of the diff is boilerplate, caused by the `socket_ext_size` computation for the SSL variant. I tried to follow the existing pattern. 

# Instructions for use

Example code will be provided in the uWebSockets PR.
