### PR TITLE
fix wording

### DIFF
--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -116,7 +116,7 @@ struct us_listen_socket_t {
     unsigned int socket_ext_size;
 };
 
-/* Listen sockets are keps in their own list */
+/* Listen sockets are kept in their own list */
 void us_internal_socket_context_link_listen_socket(struct us_socket_context_t *context, struct us_listen_socket_t *s);
 void us_internal_socket_context_unlink_listen_socket(struct us_socket_context_t *context, struct us_listen_socket_t *s);
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -93,7 +93,7 @@ int us_socket_is_established(int ssl, struct us_socket_t *s) {
     return us_internal_poll_type((struct us_poll_t *) s) != POLL_TYPE_SEMI_SOCKET;
 }
 
-/* Exactly the same as us_socket_close but does not emit on_close event */
+/* Exactly the same as us_socket_close but does not check priority or emit on_close event */
 struct us_socket_t *us_socket_close_connecting(int ssl, struct us_socket_t *s) {
     if (!us_socket_is_closed(0, s)) {
         us_internal_socket_context_unlink_socket(s->context, s);
@@ -112,7 +112,7 @@ struct us_socket_t *us_socket_close_connecting(int ssl, struct us_socket_t *s) {
     return s;
 }
 
-/* Same as above but emits on_close */
+/* Same as above but check priority and emits on_close */
 struct us_socket_t *us_socket_close(int ssl, struct us_socket_t *s, int code, void *reason) {
     if (!us_socket_is_closed(0, s)) {
         if (s->low_prio_state == 1) {


### PR DESCRIPTION
For the us_socket_close_connecting and us_socket_close part, the wordings are true 4 years ago, but later changes make it not accurate. 

So, this pull request modified the comments. 

Of course, if extracting the common logics like below, the comments could be removed without confusion.

```
void us_internal_socket_finalize(int ssl, struct us_socket_t *s) {
        /* Link this socket to the close-list and let it be deleted after this iteration */
        s->next = s->context->loop->data.closed_head;
        s->context->loop->data.closed_head = s;

        /* Any socket with prev = context is marked as closed */
        s->prev = (struct us_socket_t *) s->context;
}
```