### PR TITLE
add ALPN support to tls socket

### DIFF
--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -131,6 +131,8 @@ struct us_socket_context_options_t {
     const char *dh_params_file_name;
     const char *ca_file_name;
     const char *ssl_ciphers;
+    const char **alpn_protocols;
+    unsigned int alpn_protocols_length;
     int ssl_prefer_low_memory_usage; /* Todo: rename to prefer_low_memory_usage and apply for TCP as well */
 };
 


### PR DESCRIPTION
Hi!

I've written this PR to add ALPN support for TLS sockets. My goal for this is to make its way to uWebsockets.js, if you agree with this.

I've written this so that socket creation gets an array of protocols that are allowed (e.g. http/1.1 or h2).

I haven't written c code in very long time, so please forgive me if I've made any stupid mistakes. Any feedback is welcome.

`number_of_digits` is a bit "dumb" but I assume that it would be quickest vs a loop, and I'm not sure what the best way to do a global variable with `alpn_index` would be as well, so fixes are of course welcome as well;


usage would be something like this I assume (http/1.1 only would be used of course, when h2 is not supported):
```c
struct us_socket_context_options_t options = {};
const char *alpn[] = {"http/1.1", "h2"};
options.alpn_protocols = alpn;
options.alpn_protocols_length = 2;
...
struct us_socket_context_t *http_context = us_create_socket_context(SSL, loop, sizeof(struct http_context), options);
```

Using the above settings, I've also used openssl to validate that it works correctly (using the demo http_server.c)
```sh
➜  ~ openssl s_client -connect localhost:3000 -alpn http/1.1,h2 </dev/null 2>/dev/null | grep ALPN
ALPN protocol: http/1.1

➜  ~ openssl s_client -connect localhost:3000 -alpn h2,http/1.1 </dev/null 2>/dev/null | grep ALPN
ALPN protocol: h2

➜  ~ openssl s_client -connect localhost:3000 -alpn h2 </dev/null 2>/dev/null | grep ALPN
ALPN protocol: h2

➜  ~ openssl s_client -connect localhost:3000 -alpn http/1.1 </dev/null 2>/dev/null | grep ALPN
ALPN protocol: http/1.1

➜  ~ openssl s_client -connect localhost:3000 -alpn http/1.0 </dev/null 2>/dev/null | grep ALPN
No ALPN negotiated

➜  ~ openssl s_client -connect localhost:3000 </dev/null 2>/dev/null | grep ALPN
No ALPN negotiated
```