### PR TITLE
io_uring conversion warnings

### DIFF
--- a/src/io_uring/io_loop.c
+++ b/src/io_uring/io_loop.c
@@ -340,10 +340,14 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
     // create buffer ring here
     struct io_uring_buf_reg reg = {0};
-    posix_memalign(&reg.ring_addr, 1024 * 4, sizeof(struct io_uring_buf) * 4096);
+    {
+        void* temp_addr = NULL;
+        posix_memalign(&temp_addr, 1024 * 4, sizeof(struct io_uring_buf) * 4096);
+        reg.ring_addr = (__u64)temp_addr;
+    }
     reg.ring_entries = 4096;
     reg.bgid = 1337;
-    loop->buf_ring = reg.ring_addr;
+    loop->buf_ring = (struct io_uring_buf_ring*)reg.ring_addr;
 
     // registrera buffer ring bvuffer
     if (io_uring_register_buf_ring(&loop->ring, &reg, 0)) {


### PR DESCRIPTION
Building with liburing support fails with the following warnings:
```
...
ccache /usr/bin/cc -DLIBUS_NO_SSL -DLIBUS_USE_IO_URING -DuSocketsC_EXPORTS -I/home/paul/informatik/uSockets/src -std=gnu11 -fPIC -MD -MT CMakeFiles/uSocketsC.dir/src/io_uring/io_loop.c.o -MF CMakeFiles/uSocketsC.dir/src/io_uring/io_loop.c.o.d -o CMakeFiles/uSocketsC.dir/src/io_uring/io_loop.c.o -c /home/paul/informatik/uSockets/src/io_uring/io_loop.c
/home/paul/informatik/uSockets/src/io_uring/io_loop.c: In function ‘us_create_loop’:
/home/paul/informatik/uSockets/src/io_uring/io_loop.c:343:20: error: passing argument 1 of ‘posix_memalign’ from incompatible pointer type [-Wincompatible-pointer-types]
  343 |     posix_memalign(&reg.ring_addr, 1024 * 4, sizeof(struct io_uring_buf) * 4096);
      |                    ^~~~~~~~~~~~~~
      |                    |
      |                    __u64 * {aka long long unsigned int *}
In file included from /home/paul/informatik/uSockets/src/io_uring/internal.h:5,
                 from /home/paul/informatik/uSockets/src/io_uring/io_loop.c:23:
/usr/include/stdlib.h:718:35: note: expected ‘void **’ but argument is of type ‘__u64 *’ {aka ‘long long unsigned int *’}
  718 | extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      |                            ~~~~~~~^~~~~~~~
/home/paul/informatik/uSockets/src/io_uring/io_loop.c:346:20: error: assignment to ‘struct io_uring_buf_ring *’ from ‘__u64’ {aka ‘long long unsigned int’} makes pointer from integer without a cast [-Wint-conversion]
  346 |     loop->buf_ring = reg.ring_addr;
      |                    ^
```