### PR TITLE
fix: UDP packet buffer initialization pointing all msg_name to same address

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -251,7 +251,7 @@ void *bsd_create_udp_packet_buffer() {
         b->iov[n].iov_len = LIBUS_UDP_MAX_SIZE;
 
         b->msgvec[n].msg_hdr = (struct msghdr) {
-            .msg_name       = &b->addr,
+            .msg_name       = &b->addr[n],
             .msg_namelen    = sizeof (struct sockaddr_storage),
 
             .msg_iov        = &b->iov[n],


### PR DESCRIPTION
Fix bug in bsd_create_udp_packet_buffer() where all mmsghdr structures were pointing their msg_name field to the same address (&b->addr[0]) instead of their respective slots in the address array (&b->addr[n]).

This caused all received UDP packets to appear as coming from the same peer address when using Linux recvmmsg(), making it impossible to distinguish between different clients in UDP server applications.

Changes:
- Line 251: Change .msg_name = &b->addr to .msg_name = &b->addr[n]

Fixes issue where us_udp_packet_buffer_peer() would return identical pointers for different packet indices on Linux systems.