### PR TITLE
on_pre_open: add ip to the handler

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -418,7 +418,7 @@ struct us_socket_t *us_socket_context_adopt_socket(int ssl, struct us_socket_con
 }
 
 /* For backwards compatibility, this function will be set to nullptr by default. */
-void us_socket_context_on_pre_open(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd)) {
+void us_socket_context_on_pre_open(int ssl, struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd, char *ip, int ip_length)) {
     /* For this event, there is no difference between SSL and non-SSL */
     context->on_pre_open = on_pre_open;
 }

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -130,7 +130,7 @@ struct us_socket_context_t {
     struct us_socket_t *iterator;
     struct us_socket_context_t *prev, *next;
 
-    LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd);
+    LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd, char *ip, int ip_length);
     struct us_socket_t *(*on_open)(struct us_socket_t *, int is_client, char *ip, int ip_length);
     struct us_socket_t *(*on_data)(struct us_socket_t *, char *data, int length);
     struct us_socket_t *(*on_writable)(struct us_socket_t *);

--- a/src/libusockets.h
+++ b/src/libusockets.h
@@ -159,7 +159,7 @@ void us_socket_context_free(int ssl, struct us_socket_context_t *context);
 
 /* Setters of various async callbacks */
 void us_socket_context_on_pre_open(int ssl, struct us_socket_context_t *context,
-    LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd));
+    LIBUS_SOCKET_DESCRIPTOR (*on_pre_open)(struct us_socket_context_t *context, LIBUS_SOCKET_DESCRIPTOR fd, char *ip, int ip_length));
 void us_socket_context_on_open(int ssl, struct us_socket_context_t *context,
     struct us_socket_t *(*on_open)(struct us_socket_t *s, int is_client, char *ip, int ip_length));
 void us_socket_context_on_close(int ssl, struct us_socket_context_t *context,

--- a/src/loop.c
+++ b/src/loop.c
@@ -277,7 +277,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int events)
                     do {
                         struct us_socket_context_t *context = us_socket_context(0, &listen_socket->s);
                         /* See if we want to export the FD or keep it here (this event can be unset) */
-                        if (context->on_pre_open == 0 || context->on_pre_open(context, client_fd) == client_fd) {
+                        if (context->on_pre_open == 0 || context->on_pre_open(context, client_fd, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr)) == client_fd) {
 
                             /* Adopt the newly accepted socket */
                             us_adopt_accepted_socket(0, context,


### PR DESCRIPTION
Related to uWS.js issue [1257](https://github.com/uNetworking/uWebSockets.js/issues/1257).
Allows the IP to be exported in addition to the FD.
