### PR TITLE
preserve errno/GetLastError() in bsd_close_socket() so as not to thash errors raised by listen() etc.

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -310,10 +310,17 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_socket(int domain, int type, int protocol) {
 }
 
 void bsd_close_socket(LIBUS_SOCKET_DESCRIPTOR fd) {
+    // errno is rewritten by close(fd), and the actual error number is lost.
 #ifdef _WIN32
+    DWORD error;
+    error = GetLastError();
     closesocket(fd);
+    SetLastError(error);
 #else
+    int error; 
+    error = errno;
     close(fd);
+    errno = error;
 #endif
 }
 


### PR DESCRIPTION
When an error occurrs in many operations, the function `bsd_close_socket()` is called to close the socket before returning an error code. Unfortunately, the call to `close()`/`closesocket()` inside `bsd_close_socket()` will overwrite the value of `errno`/`GetLastError()`, making it difficult to determine the original error. For example, if I try to listen on a port that is already in use, the error (`EADDRINUSE`) get thrashed by the call to `bsd_close_socket()`, making it pretty much impossible to output/log the correct error.

This small PR saves the value of `errno`/`GetLastError()` inside `bsd_close_coket()` before calling `close()`/`closesocket()`, and restores it afterwards. This allows the error raised by the actual action (e.g. `listen()`) to be read by the caller.

**NOTE:** We submitted a pull request for this some time ago ( #196), but I think something went wrong there. I rebased the change on the latest revision and am creating a new PR. #196 is defunct and can be closed. Sorry about that.